### PR TITLE
Prioritize cert_data over kwargs (`long_course`)

### DIFF
--- a/gen_cert.py
+++ b/gen_cert.py
@@ -211,7 +211,7 @@ class CertificateGen(object):
         # lookup long names from the course_id
         try:
             self.long_org = long_org or cert_data.get('LONG_ORG', '').encode('utf-8') or settings.DEFAULT_ORG
-            self.long_course = long_course or cert_data.get('LONG_COURSE', '').encode('utf-8')
+            self.long_course = cert_data.get('LONG_COURSE', '').encode('utf-8') or long_course or ''
             self.issued_date = issued_date or cert_data.get('ISSUED_DATE', '').encode('utf-8') or 'ROLLING'
             self.interstitial_texts = collections.defaultdict(interstitial_factory())
             interstitial_dict = {

--- a/settings.py
+++ b/settings.py
@@ -110,12 +110,13 @@ if os.path.isfile(ENV_ROOT / "env.json"):
     LOG_DIR = ENV_TOKENS.get('LOG_DIR', '/var/tmp')
     local_loglevel = ENV_TOKENS.get('LOCAL_LOGLEVEL', 'INFO')
     LOGGING_DEV_ENV = ENV_TOKENS.get('LOGGING_DEV_ENV', True)
-    LOGGING = get_logger_config(LOG_DIR,
-                                logging_env=ENV_TOKENS.get('LOGGING_ENV', 'dev'),
-                                local_loglevel=local_loglevel,
-                                debug=False,
-                                dev_env=LOGGING_DEV_ENV,
-                                service_variant=os.environ.get('SERVICE_VARIANT', None))
+    LOGGING = get_logger_config(
+        LOG_DIR,
+        logging_env=ENV_TOKENS.get('LOGGING_ENV', 'dev'),
+        local_loglevel=local_loglevel,
+        debug=False,
+        dev_env=LOGGING_DEV_ENV,
+    )
     CERT_PRIVATE_DIR = ENV_TOKENS.get('CERT_PRIVATE_DIR', CERT_PRIVATE_DIR)
 
 # This is the base URL used for logging CERT uploads to s3


### PR DESCRIPTION
Since the LMS/XQueue _always_ set this value on their end (default to
`course_id`), we weren't able to override it.
