### PR TITLE
Cast fontlist `generator` back to a `list`

### DIFF
--- a/openedx_certificates/renderers/util.py
+++ b/openedx_certificates/renderers/util.py
@@ -84,6 +84,7 @@ def font_for_string(fontlist, ustring):
     # TODO: There's probably a way to do this by consulting reportlab that
     #       doesn't require re-loading the font files at all
     ustring = unicode(ustring)
+    fontlist = list(fontlist)
     if fontlist and not ustring:
         return fontlist[0]
     for fonttuple in fontlist:


### PR DESCRIPTION
This _should_ be a generator, but we overlooked that one line of code
attempts to index directly into the generator, as if it were a `dict`.

Ideally, we should rework the logic to support the generator, but
frankly, we needed a quick fix and this is the least intensive path
forward.

TODO: Fix this.
