### PR TITLE
Enable support for unicode grade in certs

### DIFF
--- a/certificate_agent.py
+++ b/certificate_agent.py
@@ -85,21 +85,25 @@ def main():
             xqueue_body = json.loads(certdata['xqueue_body'])
             xqueue_header = json.loads(certdata['xqueue_header'])
             action = xqueue_body['action']
-            username = xqueue_body['username']
-            course_id = xqueue_body['course_id']
-            course_name = xqueue_body['course_name']
-            name = xqueue_body['name']
+            username = xqueue_body['username'].encode('utf-8')
+            course_id = xqueue_body['course_id'].encode('utf-8')
+            course_name = xqueue_body['course_name'].encode('utf-8')
+            name = xqueue_body['name'].encode('utf-8')
             template_pdf = xqueue_body.get('template_pdf', None)
             grade = xqueue_body.get('grade', None)
+            if grade:
+                grade = grade.encode('utf-8')
             issued_date = xqueue_body.get('issued_date', None)
             designation = xqueue_body.get('designation', None)
+            if designation:
+                designation = designation.encode('utf-8')
             if last_course != course_id:
                 cert = CertificateGen(
                     course_id,
                     template_pdf,
                     aws_id=args.aws_id,
                     aws_key=args.aws_key,
-                    long_course=course_name.encode('utf-8'),
+                    long_course=course_name,
                     issued_date=issued_date,
                 )
                 last_course = course_id
@@ -112,17 +116,17 @@ def main():
 
         try:
             log.info(
-                u"Generating certificate for {username} ({name}), "
-                u"in {course_id}, with grade {grade}".format(
-                    username=username.encode('utf-8'),
-                    name=name.encode('utf-8'),
-                    course_id=course_id.encode('utf-8'),
+                "Generating certificate for {username} ({name}), "
+                "in {course_id}, with grade {grade}".format(
+                    username=username,
+                    name=name,
+                    course_id=course_id,
                     grade=grade,
                 )
             )
             (download_uuid,
              verify_uuid,
-             download_url) = cert.create_and_upload(name.encode('utf-8'), grade=grade.encode('utf-8'), designation=designation)
+             download_url) = cert.create_and_upload(name, grade=grade, designation=designation)
 
         except Exception as e:
             # global exception handler, if anything goes wrong

--- a/certificate_agent.py
+++ b/certificate_agent.py
@@ -112,8 +112,8 @@ def main():
 
         try:
             log.info(
-                "Generating certificate for {username} ({name}), "
-                "in {course_id}, with grade {grade}".format(
+                u"Generating certificate for {username} ({name}), "
+                u"in {course_id}, with grade {grade}".format(
                     username=username.encode('utf-8'),
                     name=name.encode('utf-8'),
                     course_id=course_id.encode('utf-8'),
@@ -122,7 +122,7 @@ def main():
             )
             (download_uuid,
              verify_uuid,
-             download_url) = cert.create_and_upload(name.encode('utf-8'), grade=grade, designation=designation)
+             download_url) = cert.create_and_upload(name.encode('utf-8'), grade=grade.encode('utf-8'), designation=designation)
 
         except Exception as e:
             # global exception handler, if anything goes wrong


### PR DESCRIPTION
Previously, certificate generation for certificates in which the
grade field included lexical characters in that are not part of
ascii would fail. This commit enables course administrators to
create certificates that with a grade field that permits any
and all unicode characters.

<img width="914" alt="screen shot 2015-10-02 at 3 37 53 pm" src="https://cloud.githubusercontent.com/assets/1752973/10260894/468c368a-6935-11e5-9faf-1cbab991e337.png">
