### PR TITLE
Disable coverage check for S3-related code

### DIFF
--- a/tests/gen_cert_test.py
+++ b/tests/gen_cert_test.py
@@ -103,7 +103,7 @@ def test_cert_names():
         (download_uuid, verify_uuid, download_url) = cert.create_and_upload(name, upload=False)
 
 
-def test_cert_upload():
+def test_cert_upload():  # pragma: no cover
     """Check here->S3->http round trip."""
     if not settings.CERT_AWS_ID or not settings.CERT_AWS_KEY:
         raise SkipTest


### PR DESCRIPTION
We already skip this test explicitly if we don't have AWS key/secret
available; this is always the case on travis-ci.

This prevents coverage.py/coveralls [1] from complaining about not testing the test :)

[1] https://coveralls.io/builds/7711623/source?filename=tests%2Fgen_cert_test.py#L110
