### PR TITLE
Cme unicode issue hotseat

### DIFF
--- a/create_pdfs.py
+++ b/create_pdfs.py
@@ -116,6 +116,8 @@ def main():
                                                        cleanup=False, designation=title, grade=grade)
             certificate_data.append((name, course, args.long_org, args.long_course, download_url))
             gen_dir = os.path.join(cert.dir_prefix, S3_CERT_PATH, download_uuid)
+            # Remove non-ascii chars from filename before saving locally (This is not the production filename)
+            name = ''.join([i if ord(i) < 128 else ' ' for i in name])
             copy_dest = '{copy_dir}/{course}-{name}.pdf'.format(
                 copy_dir=copy_dir,
                 name=name.replace(" ", "-").replace("/", "-"),

--- a/gen_cert.py
+++ b/gen_cert.py
@@ -796,12 +796,12 @@ class CertificateGen(object):
             if designation in value['titles']:
                 # Add student name designation if not Other or None
                 if designation not in ['Other', 'None']:
-                    student_name = u"{name}, {designation}".format(
+                    student_name = "{name}, {designation}".format(
                         name=student_name,
-                        designation=designation.decode('utf-8'),
+                        designation=designation,
                     )
                 achievements_string = value['credits']
-                achievements_description_string = self.cert_data['CREDITS']
+                achievements_description_string = unicode(self.cert_data['CREDITS'])
                 designation_tag = key
                 break
 

--- a/tests/gen_cert_test.py
+++ b/tests/gen_cert_test.py
@@ -84,16 +84,18 @@ def test_designation():
         for designation in designations:
             tmpdir = tempfile.mkdtemp()
             cert = CertificateGen(course_id)
-            (download_uuid, verify_uuid, download_url) = cert.create_and_upload(
-                'John Smith',
-                upload=False,
-                copy_to_webroot=True,
-                cert_web_root=tmpdir,
-                cleanup=True,
-                designation=designation,
-            )
-            if os.path.exists(tmpdir):
-                shutil.rmtree(tmpdir)
+            for name in NAMES:
+                cert = CertificateGen(course_id)
+                (download_uuid, verify_uuid, download_url) = cert.create_and_upload(
+                    name,
+                    upload=False,
+                    copy_to_webroot=True,
+                    cert_web_root=tmpdir,
+                    cleanup=True,
+                    designation=designation,
+                )
+                if os.path.exists(tmpdir):
+                    shutil.rmtree(tmpdir)
 
 
 def test_cert_names():


### PR DESCRIPTION
@stvstnfrd @dcadams @kluo @caesar2164 PR for fixing non ascii student name hot seat issue for the cme renderer.  Fixed associated test.

Creating certs with non-ascii student names like 'Raquel Sá Lopes da Slva' had two problems.
1.  Could not save pdfs for any cert locally because the student name with non-ascii chars was used in the file name.  I couldn't find a good way to do this, the code just replaces 'bad' chars with a dash
1.  CME certs would fail because there is a second formatting done on the student name because of the designations.  That was a decoding issue with a string format. 
