### PR TITLE
Add support for multiple cert tracks

### DIFF
--- a/cert-data.yml
+++ b/cert-data.yml
@@ -77,6 +77,13 @@
 #     signature_y_offset  <-- special y offset for image elements that use the 'signature_file' key
 #
 # All sizes (height, width, x/y coordinates, etc.) are in Points
+#
+# Subtemplates allow courses to have multiple certs based on user designation
+#   Add a 'subtemplates' dictionary to the desired course.  The key value 
+#   pairs in the dictionary should be 'designation': 'your subtemplate course id'
+#   Then setup 'your subtemplate course id' as a normal cert inheriting from 
+#   the same default, adding in elements to override.  The parent course is 
+#   updated with the subtemplates changes.
 
 ### 4_programmatic Default course
 Default/OpenEdX/Certificate: &certificate_defaults
@@ -392,3 +399,39 @@ translation/test/course:
       grade_interstitial: "con {grade}."
       disclaimer_text: '<b>ATENCIÓN:</b> ALGUNOS DE LOS CURSOS EN LÍNEA PODRÍAN USAR CONTENIDO DE LOS CURSOS REGULARES DE STANFORD UNIVERSITY PERO ESTO NO INDICA QUE SON EQUIVALENTES. ESTA DECLARACIÓN NO AFIRMA DE NINGUNA MANERA QUE EL PARTICIPANTE HA SIDO MATRICULADO COMO ESTUDIANTE REGULAR DE STANFORD UNIVERSITY. TAMPOCO CONFIERE NINGUNA CALIFICACIÓN, CRÉDITO DEL CURSO, O GRADO ACADÉMICO DE STANFORD UNIVERSITY, NI CONFIRMA LA IDENTIDAD DEL PARTICIPANTE.'
       verify_text: 'La autenticidad se puede confirmar en {verify_link}'
+
+Test/Subtemplates/ByDesignations:
+  <<: *certificate_defaults
+  subtemplates:
+    FACULTY: Test/Subtemplates/ByDesignations_FACULTY
+    STAFF: Test/Subtemplates/ByDesignations_STAFF
+
+Test/Subtemplates/ByDesignations_FACULTY:
+  <<: *certificate_defaults
+  interstitial:
+    Pass: 'Faculty Pass Text'
+    Distinction: 'Faculty Distinction Text'
+  instructors:
+    - instructor:
+        <<: *default_instructor_position_1
+        name_string: '<b>M. Guillaume Hébert</b>'
+        title_string: 'Head Concierge'
+        supplemental_title_string: 'Lifestyle Manager'
+        school_string: '<b>Great Bratislava Hotel</b>'
+        signature_file: 'images/test_signature.png'
+        signature_y_offset: -10
+
+Test/Subtemplates/ByDesignations_STAFF:
+  <<: *certificate_defaults
+  interstitial:
+    Pass: 'Staff Pass Text'
+    Distinction: 'Staff Distinction Text'
+  instructors:
+    - instructor:
+        <<: *default_instructor_position_1
+        name_string: '<b>M. Guillaume Hébert II</b>'
+        title_string: 'Asst. Concierge'
+        supplemental_title_string: 'Lifestyle Manager in training'
+        school_string: '<b>Great Bratislava Hotel</b>'
+        signature_file: 'images/test_signature.png'
+        signature_y_offset: -10

--- a/certificate_agent.py
+++ b/certificate_agent.py
@@ -57,9 +57,7 @@ def main():
                                 settings.QUEUE_AUTH_USER,
                                 settings.QUEUE_AUTH_PASS,
                                 settings.QUEUE_USER, settings.QUEUE_PASS)
-    last_course = None  # The last course_id we generated for
-    cert = None  # A CertificateGen instance for a particular course
-
+    cert = None
     while True:
 
         if manager.get_length() == 0:
@@ -97,7 +95,7 @@ def main():
             designation = xqueue_body.get('designation', None)
             if designation:
                 designation = designation.encode('utf-8')
-            if last_course != course_id:
+            if not (cert and cert.is_reusable(course_id, designation)):
                 cert = CertificateGen(
                     course_id,
                     template_pdf,
@@ -105,8 +103,8 @@ def main():
                     aws_key=args.aws_key,
                     long_course=course_name,
                     issued_date=issued_date,
+                    designation=designation,
                 )
-                last_course = course_id
         except (TypeError, ValueError, KeyError, IOError) as e:
             log.critical('Unable to parse queue submission ({0}) : {1}'.format(e, certdata))
             if settings.DEBUG:
@@ -126,7 +124,7 @@ def main():
             )
             (download_uuid,
              verify_uuid,
-             download_url) = cert.create_and_upload(name, grade=grade, designation=designation)
+             download_url) = cert.create_and_upload(name, grade=grade)
 
         except Exception as e:
             # global exception handler, if anything goes wrong

--- a/create_pdfs.py
+++ b/create_pdfs.py
@@ -36,9 +36,12 @@ def parse_args(args=sys.argv[1:]):
     parser.add_argument('-l', '--long-course', help='optional long course', default='')
     parser.add_argument('-i', '--issued-date', help='optional issue date')
     parser.add_argument(
-        '-T',
-        '--assign-title',
-        help='optional title string for user, CME certs have a standard list with additional logic',
+        '-d',
+        '--designation',
+        help=(
+            'optional designation string for user, '
+            'this is also used to load subtemplates'
+        ),
         default=None,
     )
     parser.add_argument('-f', '--input-file', help='optional input file for names, one name per line')
@@ -81,13 +84,25 @@ def main():
     certificate_data = []
 
     if args.course_id:
-        course_list = [args.course_id]
+        course_id = args.course_id
+        long_course = args.long_course or course_id
+        course_list = [(course_id, args.designation, long_course)]
     else:
-        course_list = settings.CERT_DATA.keys()
-
+        # Compile course list based on openedx-certificates/cert-data.yml
+        # gen_cert.py should and will fail if certificates-templates/cert-data.yml is used
+        course_list = []
+        for course_id, course_template in settings.CERT_DATA.iteritems():
+            course_list.append((course_id, None, course_id))
+            designations = course_template.get('designations', {})
+            for key, value in designations.iteritems():
+                for title in value['titles']:
+                    course_list.append((course_id, title, course_id))
+            subtemplates = course_template.get('subtemplates', {})
+            for title in subtemplates.keys():
+                course_list.append((course_id, title, course_id))
     upload_files = not args.no_upload
 
-    for course in course_list:
+    for course, designation, long_course in course_list:
         if args.name:
             name_list = [args.name]
         elif args.input_file:
@@ -106,21 +121,27 @@ def main():
                 long_org=args.long_org,
                 long_course=args.long_course,
                 issued_date=args.issued_date,
+                designation=designation,
             )
-            title = args.assign_title or None
             grade = None
             if args.grade_text:
                 grade = args.grade_text
             (download_uuid, verify_uuid,
                 download_url) = cert.create_and_upload(name, upload=upload_files, copy_to_webroot=False,
-                                                       cleanup=False, designation=title, grade=grade)
+                                                       cleanup=False, grade=grade)
             certificate_data.append((name, course, args.long_org, args.long_course, download_url))
             gen_dir = os.path.join(cert.dir_prefix, S3_CERT_PATH, download_uuid)
             # Remove non-ascii chars from filename before saving locally (This is not the production filename)
             name = ''.join([i if ord(i) < 128 else ' ' for i in name])
-            copy_dest = '{copy_dir}/{course}-{name}.pdf'.format(
+            suffix = ''
+            if designation:
+                suffix = "_{designation}".format(
+                    designation=designation,
+                )
+            copy_dest = '{copy_dir}/{course}-{name}{suffix}.pdf'.format(
                 copy_dir=copy_dir,
                 name=name.replace(" ", "-").replace("/", "-"),
+                suffix=suffix,
                 course=course.replace("/", "-"))
 
             try:

--- a/tests/gen_cert_test.py
+++ b/tests/gen_cert_test.py
@@ -87,16 +87,14 @@ def test_designation():
     for course_id in settings.CERT_DATA.keys():
         for designation in designations:
             tmpdir = tempfile.mkdtemp()
-            cert = CertificateGen(course_id)
+            cert = CertificateGen(course_id, designation=designation)
             for name in NAMES:
-                cert = CertificateGen(course_id)
                 (download_uuid, verify_uuid, download_url) = cert.create_and_upload(
                     name,
                     upload=False,
                     copy_to_webroot=True,
                     cert_web_root=tmpdir,
                     cleanup=True,
-                    designation=designation,
                 )
                 if os.path.exists(tmpdir):
                     shutil.rmtree(tmpdir)

--- a/tests/test_certificate_gen.py
+++ b/tests/test_certificate_gen.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+import unittest
+
+from ddt import ddt, data, unpack
+from nose.tools import assert_equal
+
+from gen_cert import CertificateGen
+
+
+@ddt
+class CertificateGenTests(unittest.TestCase):
+    """
+    Tests CertificateGen class
+    """
+    @data(
+        # designation, new_course_id, new_designation, result
+        (None, None, None, False),
+        (None, 'edX/DemoX_v4/Demo_Course_v4', None, True),
+        (None, 'edX/DemoX_v4/Demo_Course_v4', 'new_designation', False),
+        ('designation', None, None, False),
+        ('designation', 'edX/DemoX_v4/Demo_Course_v4', None, False),
+        ('designation', 'edX/DemoX_v4/Demo_Course_v4', 'new_designation', False),
+        ('designation', 'edX/DemoX_v4/Demo_Course_v4', 'designation', True),
+        (None, 'course-v1:edX+DemoX_v4+Custom_Instructor_Block_v4', None, False),
+        (None, 'course-v1:edX+DemoX_v4+Custom_Instructor_Block_v4', 'new_designation', False),
+        ('new_designation', 'course-v1:edX+DemoX_v4+Custom_Instructor_Block_v4', 'new_designation', False),
+    )
+    @unpack
+    def test_is_reusable(
+        self,
+        designation,
+        new_course_id,
+        new_designation,
+        result
+    ):
+        """
+        Test is_reusable return boolean based on course_id and designation
+        """
+        cert = CertificateGen(
+            'edX/DemoX_v4/Demo_Course_v4',
+            designation=designation,
+        )
+        assert_equal(cert.is_reusable(new_course_id, new_designation), result)

--- a/tests/test_subtemplates.py
+++ b/tests/test_subtemplates.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+import os
+import shutil
+import tempfile
+import unittest
+
+from nose.tools import assert_true
+from nose.tools import assert_equal
+from nose.tools import assert_in
+
+import settings
+from gen_cert import CertificateGen
+from test_data import NAMES
+
+
+class CertificateSubtemplateTests(unittest.TestCase):
+    """
+    Tests the subtemplates feature for certs
+
+    Subtemplates are currently written to key on designations only
+    """
+    subtemplate_courses = [
+        'Test/Subtemplates/ByDesignations',
+    ]
+
+    def test_subtemplate_courses_exist(self):
+        """
+        Check that the subtemplate courses exist in settings.CERT_DATA
+        """
+        found_sub_course_ids = [
+            course_id
+            for course_id, course_data in settings.CERT_DATA.iteritems()
+            if 'subtemplates' in course_data
+        ]
+        assert_equal(
+            set(self.subtemplate_courses),
+            set(found_sub_course_ids)
+        )
+
+    def test_subtemplate_courses_have_proper_data(self):
+        """
+        Check that subtemplates have proper key-value pairs in 'subtemplates'
+        """
+        for course_id in self.subtemplate_courses:
+            cert_data = settings.CERT_DATA[course_id]
+            subtemplates = cert_data['subtemplates']
+            assert_true(isinstance(subtemplates, dict))
+            for designation, sub_course_id in subtemplates.iteritems():
+                assert_in(sub_course_id, settings.CERT_DATA)
+
+    def test_subtemplates(self):
+        """
+        Generates certficates with subtemplates
+        """
+        tmpdir = tempfile.mkdtemp()
+        for course_id in self.subtemplate_courses:
+            cert_data = settings.CERT_DATA[course_id]
+            subtemplates = cert_data['subtemplates']
+            for designation, course_id in subtemplates.iteritems():
+                cert = CertificateGen(course_id, designation=designation)
+                for name in NAMES:
+                    (download_uuid, verify_uuid, download_url) = cert.create_and_upload(
+                        name,
+                        upload=False,
+                        copy_to_webroot=True,
+                        cert_web_root=tmpdir,
+                        cleanup=True,
+                    )
+        if os.path.exists(tmpdir):
+            shutil.rmtree(tmpdir)


### PR DESCRIPTION
@stvstnfrd @caesar2164 PR for adding multiple cert tracks for a single course based on user title/designation.    

course-v1:CME+014+PostTest was the recent addition inheriting from the a CME_DEFAULTS_RN.  
This course now has sub-templating to allow different cert tracks per course depending on  title/designation.  Any new course, cme or otherwise, can add a subtemplates dict in the yaml where the key/value pairs are title/subtemplate_course_id.   I created a DEBUG course to show it's usage in lagunita_defaults, course-v1:ComputerScience+MMDS+DEBUG  

Sub-templates can be used to update a course cert along multiple tracks.  The default track is what is contained in the default course_id cert data.  If a subtemplate is recognized at runtime then it's yaml data is pulled into the default course_id cert data. 

This PR demonstrates the functionality with minimal code changes.  There were a couple of pending questions from our meeting.  How do we want to override(in the case we're using Dict.update()) cert data with the sub template data, do we want to change cme_defaults yaml designations, and, from the trello card, multiple grading policies / tiered tracks in the future.  The last would need to specify sub-templates based on grade along with designation.

https://github.com/Stanford-Online/certificate-templates/pull/116