### PR TITLE
Stop mutating shared dictionary

### DIFF
--- a/gen_cert.py
+++ b/gen_cert.py
@@ -148,6 +148,9 @@ class CertificateGen(object):
         self.aws_key = str(aws_key)
 
         cert_data = settings.CERT_DATA.get(course_id, {})
+        # instantiate a new local dictionary instance
+        # so that any changes are not shared globally
+        cert_data = dict(cert_data)
         self.course_id = course_id
         self.designation = designation
         subtemplates = cert_data.get('subtemplates', {})


### PR DESCRIPTION
Since dictionaries are a mutable data structure,
when we updated the local reference to the course's cert_data,
we were actually mutating the main, shared, cert_data.

By instantiating a new instance of the dictionary,
we ensure that any mutations are not reflected in the shared data
structure.