### PR TITLE
Pin Pillow package under v6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ gnupg==1.4.0
 nose==1.2.1
 path.py==2.4.1
 pep8==1.5.7
+Pillow<6.0.0
 pyPdf2==1.23
 python-bidi==0.3.4
 PyYAML==3.11


### PR DESCRIPTION
to work around a package conflict following the removal of its `VERSION`
attribute [1].

- [1] https://github.com/python-pillow/Pillow/pull/3624